### PR TITLE
fix memcached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM php:5.6-fpm
 
 # Install packages
 RUN apt-get update &&\
-  apt-get install -y nginx supervisor curl unzip php5-memcached &&\
+  apt-get install -y nginx supervisor curl unzip libz-dev libmemcached-dev &&\
   rm -r /var/lib/apt/lists/*
 
-RUN pecl install xdebug
+RUN pecl install xdebug memcached
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/docker/php/conf.d/memcached.ini
+++ b/docker/php/conf.d/memcached.ini
@@ -1,1 +1,1 @@
-zend_extension=memcached.so
+extension=memcached.so


### PR DESCRIPTION
Fixed: 
PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20131226/memcached.so' - /usr/local/lib/php/extensions/no-debug-non-zts-20131226/memcached.so: cannot open shared object file

as mentioned in https://github.com/drgomesp/symfony-docker/issues/19
