### PR TITLE
[FIX] under dependencie in package.json for gulp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "browser-sync": "^2.18.8",
     "del": "^2.2.2",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#v4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-cssmin": "^0.1.7",
     "gulp-sass": "^3.1.0",


### PR DESCRIPTION
The gulp version in package.json is mentioned as
`"gulp": "github:gulpjs/gulp#4.0",`

 Which throws the below error,

> npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
> npm WARN deprecated gulp-util@2.2.20: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
> npm WARN deprecated graceful-fs@2.0.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
> npm ERR! code 1
> npm ERR! Command failed: C:\Program Files\Git\cmd\git.EXE checkout 4.0
> npm ERR! error: pathspec '4.0' did not match any file(s) known to git
> npm ERR!
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     C:\Users\rafa\AppData\Roaming\npm-cache\_logs\2019-02-13T18_52_53_136Z-debug.log

Seems like this should like this,

> "gulp": "github:gulpjs/gulp#v4.0.0"

As there is no more a 4.0 tag [https://github.com/gulpjs/gulp](https://github.com/gulpjs/gulp)